### PR TITLE
[Feat/22-admin-recruit]: 지원서 현황 및 세부 조회

### DIFF
--- a/src/main/java/com/like_lion/tomato/domain/member/entity/Member.java
+++ b/src/main/java/com/like_lion/tomato/domain/member/entity/Member.java
@@ -146,4 +146,9 @@ public class Member {
                         this.role == Role.ROLE_MASTER
                 );
     }
+
+    public boolean hasAdminRoleOrHigher() {
+        return this.role != null &&
+                (this.role == Role.ROLE_ADMIN || this.role == Role.ROLE_MASTER);
+    }
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/api/ApplicationController.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/api/ApplicationController.java
@@ -1,19 +1,17 @@
 package com.like_lion.tomato.domain.recruitment.api;
 
 import com.like_lion.tomato.domain.recruitment.dto.applicant.ApplicantResponse;
+import com.like_lion.tomato.domain.recruitment.dto.applicant.StatusResponse;
 import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationRequest;
 import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationResponse;
-import com.like_lion.tomato.domain.recruitment.dto.question.QuestionResponse;
 import com.like_lion.tomato.domain.recruitment.service.application.ApplicantService;
 import com.like_lion.tomato.domain.recruitment.service.application.ApplicationService;
-import com.like_lion.tomato.domain.recruitment.service.application.RecruitmentQuestionService;
 import com.like_lion.tomato.global.common.enums.Part;
 import com.like_lion.tomato.global.exception.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/recruit")
@@ -46,12 +44,22 @@ public class ApplicationController {
         return ApiResponse.success(response);
     }
 
-    @GetMapping("/applicants")
-    public ApiResponse<List<ApplicantResponse>> getApplicants(
-            @RequestParam Part part,
+    @GetMapping("/applicants/{applicationId}")
+    public ApiResponse<ApplicantResponse.Detail> getApplicantDetail(
+            @PathVariable String applicationId,
             @RequestHeader("Authorization") String authorization
     ) {
-        List<ApplicantResponse> response = applicantService.getApplicants(part, authorization);
+        ApplicantResponse.Detail response = applicantService.getApplicantDetail(applicationId, authorization);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/applicants")
+    public ApiResponse<StatusResponse> getApplicants(
+            @RequestParam Part part,
+            @RequestParam @NotNull Integer round,
+            @RequestHeader("Authorization") String authorization
+    ) {
+        StatusResponse response = applicantService.getApplicants(part, round, authorization);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/api/ApplicationController.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/api/ApplicationController.java
@@ -1,8 +1,10 @@
 package com.like_lion.tomato.domain.recruitment.api;
 
+import com.like_lion.tomato.domain.recruitment.dto.applicant.ApplicantResponse;
 import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationRequest;
 import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationResponse;
 import com.like_lion.tomato.domain.recruitment.dto.question.QuestionResponse;
+import com.like_lion.tomato.domain.recruitment.service.application.ApplicantService;
 import com.like_lion.tomato.domain.recruitment.service.application.ApplicationService;
 import com.like_lion.tomato.domain.recruitment.service.application.RecruitmentQuestionService;
 import com.like_lion.tomato.global.common.enums.Part;
@@ -11,18 +13,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/recruit")
 @RequiredArgsConstructor
 public class ApplicationController {
-    private final RecruitmentQuestionService questionService;
     private final ApplicationService applicationService;
-
-    @GetMapping("/questions/{part}")
-    public ApiResponse<QuestionResponse> getQuestionsByPart(@PathVariable Part part) {
-        QuestionResponse response = questionService.getQuestionsByPart(part);
-        return ApiResponse.success(response);
-    }
+    private final ApplicantService applicantService;
 
     @PostMapping("/application")
     public ApiResponse<ApplicationResponse> submitApplication(
@@ -45,6 +43,15 @@ public class ApplicationController {
             @RequestHeader("Authorization") String authorization
     ) {
         ApplicationResponse response = applicationService.draftApplication(request, authorization);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/applicants")
+    public ApiResponse<List<ApplicantResponse>> getApplicants(
+            @RequestParam Part part,
+            @RequestHeader("Authorization") String authorization
+    ) {
+        List<ApplicantResponse> response = applicantService.getApplicants(part, authorization);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/api/QuestionController.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/api/QuestionController.java
@@ -1,0 +1,28 @@
+package com.like_lion.tomato.domain.recruitment.api;
+
+import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationRequest;
+import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationResponse;
+import com.like_lion.tomato.domain.recruitment.dto.question.QuestionResponse;
+import com.like_lion.tomato.domain.recruitment.service.application.ApplicationService;
+import com.like_lion.tomato.domain.recruitment.service.application.RecruitmentQuestionService;
+import com.like_lion.tomato.global.common.enums.Part;
+import com.like_lion.tomato.global.exception.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/recruit")
+@RequiredArgsConstructor
+public class QuestionController {
+    private final RecruitmentQuestionService questionService;
+    private final ApplicationService applicationService;
+
+    @GetMapping("/questions/{part}")
+    public ApiResponse<QuestionResponse> getQuestionsByPart(@PathVariable Part part) {
+        QuestionResponse response = questionService.getQuestionsByPart(part);
+        return ApiResponse.success(response);
+    }
+
+
+}

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/dto/applicant/ApplicantResponse.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/dto/applicant/ApplicantResponse.java
@@ -1,79 +1,98 @@
 package com.like_lion.tomato.domain.recruitment.dto.applicant;
 
-import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationResponse;
 import com.like_lion.tomato.domain.recruitment.dto.question.QuestionAnswerDto;
 import com.like_lion.tomato.domain.recruitment.entity.application.Application;
-import com.like_lion.tomato.domain.recruitment.service.application.ApplicantService;
+import com.like_lion.tomato.domain.recruitment.entity.constant.ApplicationStatus;
 import com.like_lion.tomato.global.common.enums.Part;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.function.Function;
 
 @Builder
 public record ApplicantResponse(
         String id,
         String name,
-        String major,
-        String studentId,
-        String email,
-        String phone,
-        List<QuestionAnswerDto> commonAnswers,
-        List<QuestionAnswerDto> partAnswers,
-        String portfolioUrls,
-        Part part,
+        ApplicationStatus status,
         LocalDateTime appliedAt,
         String reviewerId
 ) {
-    @Builder
+
     public static ApplicantResponse from(Application application, String reviewerId) {
-        List<QuestionAnswerDto> commonAnswers = application.getCommonAnswers().stream()
-                .map(QuestionAnswerDto::fromCommon)
-                .toList();
-
-        List<QuestionAnswerDto> partAnswers = application.getPartAnswers().stream()
-                .map(QuestionAnswerDto::fromPart)
-                .toList();
-
-        return ApplicantResponse.builder()
-                .id(application.getId())
-                .name(application.getUsername())
-                .major(application.getMajor())
-                .studentId(application.getStudentId())
-                .email(application.getMember().getEmail())
-                .phone(application.getPhone())
-                .commonAnswers(commonAnswers)
-                .partAnswers(partAnswers)
-                .portfolioUrls(application.getPortfolioUrl())
-                .part(application.getPart())
-                .appliedAt(application.getSubmittedAt())
-                .reviewerId(reviewerId)
-                .build();
+        return new ApplicantResponse(
+                application.getId(),
+                application.getUsername(),
+                application.getStatus(),
+                application.getSubmittedAt(),
+                reviewerId
+        );
     }
 
-    public static ApplicantResponse fromPart(Application application, Part part, String reviewerId) {
-        List<QuestionAnswerDto> commonAnswers = application.getCommonAnswers().stream()
-                .map(QuestionAnswerDto::fromCommon)
-                .toList();
+    @Builder
+    public record Detail(
+            String id,
+            String name,
+            String major,
+            String studentId,
+            String email,
+            String phone,
+            List<QuestionAnswerDto> commonAnswers,
+            List<QuestionAnswerDto> partAnswers,
+            String portfolioUrls,
+            Part part,
+            LocalDateTime appliedAt,
+            String reviewerId
+    ) {
+        public static Detail from(Application application, String reviewerId) {
+            List<QuestionAnswerDto> commonAnswers = application.getCommonAnswers().stream()
+                    .map(QuestionAnswerDto::fromCommon)
+                    .toList();
 
-        List<QuestionAnswerDto> partAnswers = application.getPartAnswers().stream()
-                .map(QuestionAnswerDto::fromPart)
-                .toList();
+            List<QuestionAnswerDto> partAnswers = application.getPartAnswers().stream()
+                    .map(QuestionAnswerDto::fromPart)
+                    .toList();
 
-        return ApplicantResponse.builder()
-                .id(application.getId())
-                .name(application.getUsername())
-                .major(application.getMajor())
-                .studentId(application.getStudentId())
-                .email(application.getMember().getEmail())
-                .phone(application.getPhone())
-                .commonAnswers(commonAnswers)
-                .partAnswers(partAnswers)
-                .portfolioUrls(application.getPortfolioUrl())
-                .part(part)
-                .appliedAt(application.getSubmittedAt())
-                .reviewerId(reviewerId)
-                .build();
+            return Detail.builder()
+                    .id(application.getId())
+                    .name(application.getUsername())
+                    .major(application.getMajor())
+                    .studentId(application.getStudentId())
+                    .email(application.getMember().getEmail())
+                    .phone(application.getPhone())
+                    .commonAnswers(commonAnswers)
+                    .partAnswers(partAnswers)
+                    .portfolioUrls(application.getPortfolioUrl())
+                    .part(application.getPart())
+                    .appliedAt(application.getSubmittedAt())
+                    .reviewerId(reviewerId)
+                    .build();
+        }
+
+        public static Detail fromPart(Application application, Part part, String reviewerId) {
+            List<QuestionAnswerDto> commonAnswers = application.getCommonAnswers().stream()
+                    .map(QuestionAnswerDto::fromCommon)
+                    .toList();
+
+            List<QuestionAnswerDto> partAnswers = application.getPartAnswers().stream()
+                    .map(QuestionAnswerDto::fromPart)
+                    .toList();
+
+            return Detail.builder()
+                    .id(application.getId())
+                    .name(application.getUsername())
+                    .major(application.getMajor())
+                    .studentId(application.getStudentId())
+                    .email(application.getMember().getEmail())
+                    .phone(application.getPhone())
+                    .commonAnswers(commonAnswers)
+                    .partAnswers(partAnswers)
+                    .portfolioUrls(application.getPortfolioUrl())
+                    .part(part)
+                    .appliedAt(application.getSubmittedAt())
+                    .reviewerId(reviewerId)
+                    .build();
+        }
     }
+
+
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/dto/applicant/ApplicantResponse.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/dto/applicant/ApplicantResponse.java
@@ -1,0 +1,79 @@
+package com.like_lion.tomato.domain.recruitment.dto.applicant;
+
+import com.like_lion.tomato.domain.recruitment.dto.application.ApplicationResponse;
+import com.like_lion.tomato.domain.recruitment.dto.question.QuestionAnswerDto;
+import com.like_lion.tomato.domain.recruitment.entity.application.Application;
+import com.like_lion.tomato.domain.recruitment.service.application.ApplicantService;
+import com.like_lion.tomato.global.common.enums.Part;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+@Builder
+public record ApplicantResponse(
+        String id,
+        String name,
+        String major,
+        String studentId,
+        String email,
+        String phone,
+        List<QuestionAnswerDto> commonAnswers,
+        List<QuestionAnswerDto> partAnswers,
+        String portfolioUrls,
+        Part part,
+        LocalDateTime appliedAt,
+        String reviewerId
+) {
+    @Builder
+    public static ApplicantResponse from(Application application, String reviewerId) {
+        List<QuestionAnswerDto> commonAnswers = application.getCommonAnswers().stream()
+                .map(QuestionAnswerDto::fromCommon)
+                .toList();
+
+        List<QuestionAnswerDto> partAnswers = application.getPartAnswers().stream()
+                .map(QuestionAnswerDto::fromPart)
+                .toList();
+
+        return ApplicantResponse.builder()
+                .id(application.getId())
+                .name(application.getUsername())
+                .major(application.getMajor())
+                .studentId(application.getStudentId())
+                .email(application.getMember().getEmail())
+                .phone(application.getPhone())
+                .commonAnswers(commonAnswers)
+                .partAnswers(partAnswers)
+                .portfolioUrls(application.getPortfolioUrl())
+                .part(application.getPart())
+                .appliedAt(application.getSubmittedAt())
+                .reviewerId(reviewerId)
+                .build();
+    }
+
+    public static ApplicantResponse fromPart(Application application, Part part, String reviewerId) {
+        List<QuestionAnswerDto> commonAnswers = application.getCommonAnswers().stream()
+                .map(QuestionAnswerDto::fromCommon)
+                .toList();
+
+        List<QuestionAnswerDto> partAnswers = application.getPartAnswers().stream()
+                .map(QuestionAnswerDto::fromPart)
+                .toList();
+
+        return ApplicantResponse.builder()
+                .id(application.getId())
+                .name(application.getUsername())
+                .major(application.getMajor())
+                .studentId(application.getStudentId())
+                .email(application.getMember().getEmail())
+                .phone(application.getPhone())
+                .commonAnswers(commonAnswers)
+                .partAnswers(partAnswers)
+                .portfolioUrls(application.getPortfolioUrl())
+                .part(part)
+                .appliedAt(application.getSubmittedAt())
+                .reviewerId(reviewerId)
+                .build();
+    }
+}

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/dto/applicant/StatusResponse.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/dto/applicant/StatusResponse.java
@@ -1,0 +1,10 @@
+package com.like_lion.tomato.domain.recruitment.dto.applicant;
+
+import java.util.List;
+
+public record StatusResponse(
+        int round,
+        String part,
+        List<ApplicantResponse> applicantResponse
+) {
+}

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/exception/RecruitmentErrorCode.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/exception/RecruitmentErrorCode.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RecruitmentErrorCode implements ErrorCode {
     // 잘못된 요청 오류
+    INVALID_ROUND(400, "올바른 라운드 범위가 아닙니다 (1 또는 2)"),
     INVALID_NAME_FORMAT(400, "올바른 이름 형식이 아닙니다"),
     INVALID_PHONE_FORMAT(400, "올바른 전화번호 형식이 아닙니다"),
     INVALID_STUDENT_ID_FORMAT(400, "올바른 학번 형식이 아닙니다"),

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/repository/application/ApplicationRepository.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/repository/application/ApplicationRepository.java
@@ -1,8 +1,11 @@
 package com.like_lion.tomato.domain.recruitment.repository.application;
 
 import com.like_lion.tomato.domain.recruitment.entity.application.Application;
+import com.like_lion.tomato.domain.recruitment.entity.constant.ApplicationStatus;
+import com.like_lion.tomato.global.common.enums.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<Application, String> {
@@ -15,4 +18,8 @@ public interface ApplicationRepository extends JpaRepository<Application, String
     void deleteByMemberIdAndSubmittedAtIsNull(String memberId);
 
     Optional<Application> findByMemberIdAndSubmittedAtIsNull(String memberId);
+
+    List<Application> findAllByStatusAndPart(ApplicationStatus status, Part part);
+
+    List<Application> findAllByStatus(ApplicationStatus status);
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/repository/application/ApplicationRepository.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/repository/application/ApplicationRepository.java
@@ -1,11 +1,8 @@
 package com.like_lion.tomato.domain.recruitment.repository.application;
 
 import com.like_lion.tomato.domain.recruitment.entity.application.Application;
-import com.like_lion.tomato.global.common.enums.Part;
-import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<Application, String> {
@@ -18,8 +15,4 @@ public interface ApplicationRepository extends JpaRepository<Application, String
     void deleteByMemberIdAndSubmittedAtIsNull(String memberId);
 
     Optional<Application> findByMemberIdAndSubmittedAtIsNull(String memberId);
-
-    List<Application> findAllBySubmittedIsNotNullAndPart(Part part);
-
-    List<Application> findAllBySubmittedIsNotNull();
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/repository/application/ApplicationRepository.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/repository/application/ApplicationRepository.java
@@ -1,8 +1,11 @@
 package com.like_lion.tomato.domain.recruitment.repository.application;
 
 import com.like_lion.tomato.domain.recruitment.entity.application.Application;
+import com.like_lion.tomato.global.common.enums.Part;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<Application, String> {
@@ -15,4 +18,8 @@ public interface ApplicationRepository extends JpaRepository<Application, String
     void deleteByMemberIdAndSubmittedAtIsNull(String memberId);
 
     Optional<Application> findByMemberIdAndSubmittedAtIsNull(String memberId);
+
+    List<Application> findAllBySubmittedIsNotNullAndPart(Part part);
+
+    List<Application> findAllBySubmittedIsNotNull();
 }

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/service/application/ApplicantService.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/service/application/ApplicantService.java
@@ -1,0 +1,46 @@
+package com.like_lion.tomato.domain.recruitment.service.application;
+
+import com.like_lion.tomato.domain.auth.exception.AuthErrorCode;
+import com.like_lion.tomato.domain.auth.exception.AuthException;
+import com.like_lion.tomato.domain.member.entity.Member;
+import com.like_lion.tomato.domain.member.exception.MemberErrorCode;
+import com.like_lion.tomato.domain.member.exception.MemberException;
+import com.like_lion.tomato.domain.member.repository.MemberRepository;
+import com.like_lion.tomato.domain.recruitment.dto.applicant.ApplicantResponse;
+import com.like_lion.tomato.domain.recruitment.repository.application.ApplicationRepository;
+import com.like_lion.tomato.global.auth.implement.JwtTokenProvider;
+import com.like_lion.tomato.global.common.enums.Part;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicantService {
+    private final MemberRepository memberRepository;
+    private final ApplicationRepository applicationRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public List<ApplicantResponse> getApplicants(Part part, String authorization) {
+        String memberId = jwtTokenProvider.extractMemberIdFromToken(authorization);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (!member.hasAdminRoleOrHigher()) {
+            throw new AuthException((AuthErrorCode.ADMIN_REQUIRED));
+        }
+
+        if (part == null) {
+            return applicationRepository.findAllBySubmittedIsNotNull().stream()
+                    .map(application -> ApplicantResponse.from(application, member.getId()))
+                    .toList();
+        } else {
+            return applicationRepository.findAllBySubmittedIsNotNullAndPart((part))
+                    .stream()
+                    .map(application -> ApplicantResponse.fromPart(application, part, member.getId()))
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/com/like_lion/tomato/domain/recruitment/service/application/ApplicantService.java
+++ b/src/main/java/com/like_lion/tomato/domain/recruitment/service/application/ApplicantService.java
@@ -7,13 +7,23 @@ import com.like_lion.tomato.domain.member.exception.MemberErrorCode;
 import com.like_lion.tomato.domain.member.exception.MemberException;
 import com.like_lion.tomato.domain.member.repository.MemberRepository;
 import com.like_lion.tomato.domain.recruitment.dto.applicant.ApplicantResponse;
+import com.like_lion.tomato.domain.recruitment.dto.applicant.StatusResponse;
+import com.like_lion.tomato.domain.recruitment.entity.application.Application;
+import com.like_lion.tomato.domain.recruitment.entity.constant.ApplicationStatus;
+import com.like_lion.tomato.domain.recruitment.exception.RecruitmentErrorCode;
+import com.like_lion.tomato.domain.recruitment.exception.RecruitmentException;
 import com.like_lion.tomato.domain.recruitment.repository.application.ApplicationRepository;
 import com.like_lion.tomato.global.auth.implement.JwtTokenProvider;
 import com.like_lion.tomato.global.common.enums.Part;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+
+import static com.like_lion.tomato.domain.recruitment.dto.applicant.ApplicantResponse.*;
+import static com.like_lion.tomato.domain.recruitment.entity.constant.ApplicationStatus.FIRST_PASS;
+import static com.like_lion.tomato.domain.recruitment.entity.constant.ApplicationStatus.SUBMITTED;
 
 @Service
 @RequiredArgsConstructor
@@ -22,25 +32,56 @@ public class ApplicantService {
     private final ApplicationRepository applicationRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public List<ApplicantResponse> getApplicants(Part part, String authorization) {
-        String memberId = jwtTokenProvider.extractMemberIdFromToken(authorization);
+    public Detail getApplicantDetail(String applicationId, String authorization) {
+        String reviewerId = jwtTokenProvider.extractMemberIdFromToken(authorization);
 
-        Member member = memberRepository.findById(memberId)
+        Member reviewer = memberRepository.findById(reviewerId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (!member.hasAdminRoleOrHigher()) {
+        if (!reviewer.hasAdminRoleOrHigher()) {
             throw new AuthException((AuthErrorCode.ADMIN_REQUIRED));
         }
 
-        if (part == null) {
-            return applicationRepository.findAllBySubmittedIsNotNull().stream()
-                    .map(application -> ApplicantResponse.from(application, member.getId()))
-                    .toList();
-        } else {
-            return applicationRepository.findAllBySubmittedIsNotNullAndPart((part))
-                    .stream()
-                    .map(application -> ApplicantResponse.fromPart(application, part, member.getId()))
-                    .toList();
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new RecruitmentException(RecruitmentErrorCode.APPLICATION_NOT_FOUND));
+
+        return Detail.from(application, reviewer.getId());
+    }
+
+    public StatusResponse getApplicants(Part part, @NotNull Integer round, String authorization) {
+        String reviewerId = jwtTokenProvider.extractMemberIdFromToken(authorization);
+
+        Member reviewer = memberRepository.findById(reviewerId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (!reviewer.hasAdminRoleOrHigher()) {
+            throw new AuthException((AuthErrorCode.ADMIN_REQUIRED));
         }
+        ApplicationStatus status = getStatusByRound(round);
+        List<Application> applications = getApplications(status, part);
+
+        List<ApplicantResponse> applicantsInfo = applications.stream()
+                .map(application -> from(application, reviewer.getId()))
+                .toList();
+
+        if (part == null) {
+            return new StatusResponse(round, "ALL", applicantsInfo);
+        } else {
+            return new StatusResponse(round, part.toString(), applicantsInfo);
+        }
+    }
+
+    private ApplicationStatus getStatusByRound(int round) {
+        return switch (round) {
+            case 1 -> SUBMITTED;
+            case 2 -> FIRST_PASS;
+            default -> throw new RecruitmentException(RecruitmentErrorCode.INVALID_ROUND);
+        };
+    }
+
+    private List<Application> getApplications(ApplicationStatus status, Part part) {
+        return (part == null)
+                ? applicationRepository.findAllByStatus(status)
+                : applicationRepository.findAllByStatusAndPart(status, part);
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#35 

## 작업 내용
- 전체 혹은 파트별로 심사 회차별 지원서 조회
- 지원서 단일 세부 조회
- 관련 서비스 로직에서 어드민 이상의 권한 검증

### 스크린샷 (선택)

### 참고자료 (선택)
